### PR TITLE
Fix bug failed upload message toasted when user cancel pick file

### DIFF
--- a/domain/lib/src/usecases/file_picker/file_picker_view_state.dart
+++ b/domain/lib/src/usecases/file_picker/file_picker_view_state.dart
@@ -49,3 +49,8 @@ class FilePickerFailure extends FeatureFailure {
   @override
   List<Object> get props => [exception];
 }
+
+class FilePickerCancel extends FeatureFailure {
+  @override
+  List<Object> get props => [];
+}

--- a/lib/presentation/util/local_file_picker.dart
+++ b/lib/presentation/util/local_file_picker.dart
@@ -35,7 +35,7 @@ import 'package:file_picker/file_picker.dart';
 
 class LocalFilePicker {
 
-  Future<Either<FilePickerFailure, FilePickerSuccessViewState>>
+  Future<Either<Failure, FilePickerSuccessViewState>>
       pickSingleFile() async {
     try {
       final fileResult = await FilePicker.platform.pickFiles();
@@ -45,7 +45,7 @@ class LocalFilePicker {
             _getSingleFilePathWithoutFileName(fileResult),
             fileResult.files.single.size)));
       } else {
-        return Left(FilePickerFailure(Exception('unknown file picker')));
+        return Left(FilePickerCancel());
       }
     } catch (exception) {
       return Left(FilePickerFailure(exception));

--- a/lib/presentation/widget/myspace/my_space_widget.dart
+++ b/lib/presentation/widget/myspace/my_space_widget.dart
@@ -297,8 +297,12 @@ class _MySpaceWidgetState extends State<MySpaceWidget> {
   Widget handleUploadToastMessage(
       BuildContext context, dartz.Either<Failure, Success> uploadFileState) {
     uploadFileState.fold(
-        (failure) => appToast.showToast(
-            AppLocalizations.of(context).upload_failure_text),
+        (failure) => {
+          if (failure is FilePickerFailure || failure is UploadFileFailure) {
+            appToast.showToast(
+                AppLocalizations.of(context).upload_failure_text)
+          }
+        },
         (success) => {
           if (success is UploadFileSuccess) {
             appToast.showToast(AppLocalizations.of(context).upload_success_text),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -105,7 +105,6 @@ flutter:
   # To add assets to your application, add an assets section, like this:
   assets:
     - assets/images/
-    - assets/lang/
 
   # An image asset can refer to one or more resolution-specific "variants", see
   # https://flutter.dev/assets-and-images/#resolution-aware.


### PR DESCRIPTION
Currently, after user go to pick file screen and then press cancel, failed upload message is toasted which should not happen. This PR is to fix it. 
I also remove unused `lang` folder in `pubspec`
@imGok @hoangdat please review this.