### PR TITLE
LA-634: Add photo library usage description

### DIFF
--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -42,23 +42,24 @@
 		<string>UIInterfaceOrientationPortraitUpsideDown</string>
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
-    </array>
-    <key>UIViewControllerBasedStatusBarAppearance</key>
-    <false/>
-    <key>CFBundleURLTypes</key>
-    <array>
-        <dict>
-            <key>CFBundleTypeRole</key>
-            <string>Editor</string>
-            <key>CFBundleURLSchemes</key>
-            <array>
-                <string>com.linagora.linshare</string>
-            </array>
-        </dict>
-        <dict/>
-    </array>
-    
-    <key>NSPhotoLibraryUsageDescription</key>
-    <string>To upload photos, please allow permission to access your photo library.</string>
+	</array>
+	<key>UIViewControllerBasedStatusBarAppearance</key>
+	<false/>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>com.linagora.linshare</string>
+			</array>
+		</dict>
+		<dict/>
+	</array>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>To select and upload photo, we need permission to access your photo library.</string>
+	<key>NSPhotoLibraryAddUsageDescription</key>
+	<string>To save photo to library, we need permission to access your photo library.</string>
 </dict>
 </plist>


### PR DESCRIPTION
@imGok @hoangdat @ngohado Please review this. I was fixing the following message from app store

> 
ITMS-90683: Missing Purpose String in Info.plist - Your app's code references one or more APIs that access sensitive user data. The app's Info.plist file should contain a NSPhotoLibraryUsageDescription key with a user-facing purpose string explaining clearly and completely why your app needs the data. Starting Spring 2019, all apps submitted to the App Store that access user data are required to include a purpose string. If you're using external libraries or SDKs, they may reference APIs that require a purpose string. While your app might not use these APIs, a purpose string is still required. You can contact the developer of the library or SDK and request they release a version of their code that doesn't contain the APIs. Learn more (https://developer.apple.com/documentation/uikit/core_app/protecting_the_user_s_privacy).