### PR TITLE
LA-102: avoid crash when upload multiple files in iOS

### DIFF
--- a/data/pubspec.yaml
+++ b/data/pubspec.yaml
@@ -31,7 +31,7 @@ dependencies:
   shared_preferences: ^0.5.12
 
   # flutter_uploader
-  flutter_uploader: ^1.2.0
+  flutter_uploader: ^1.2.1
 
   # flutter_downloader
   flutter_downloader: ^1.5.2

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -61,11 +61,9 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
-	<!-- changes this number to configure the maximum number of concurrent tasks -->
-    <key>FUMaximumConnectionsPerHost</key>
-    <integer>3</integer>
-	<!-- changes this number to configure the maximum number of concurrent tasks -->
-    <key>FUMaximumUploadOperation</key>
-    <integer>3</integer>
+	<key>FUMaximumConnectionsPerHost</key>
+	<integer>1</integer>
+	<key>FUMaximumUploadOperation</key>
+	<integer>1</integer>
 </dict>
 </plist>

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -61,7 +61,7 @@ dependencies:
   file_picker: 2.0.11
 
   # flutter_uploader
-  flutter_uploader: ^1.2.0
+  flutter_uploader: ^1.2.1
 
   # flutter toast
   fluttertoast: ^7.1.1


### PR DESCRIPTION
Refer to this bug: [https://app.zenhub.com/workspaces/linshare-flutter-5fe04e3547c3510015c66915/issues/linagora/linshare-mobile-flutter-app/102undefined](https://app.zenhub.com/workspaces/linshare-flutter-5fe04e3547c3510015c66915/issues/linagora/linshare-mobile-flutter-app/102undefined)