### PR TITLE
LA-97: update receive_sharing_intent library version syntax

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,7 +70,7 @@ dependencies:
   redux_logging: ^0.4.0
 
   # receive_sharing_intent
-  receive_sharing_intent: ^1.4.1
+  receive_sharing_intent: 1.4.1
 
   # intl
   intl: ^0.16.1


### PR DESCRIPTION
refer to this bug [https://github.com/linagora/linshare-mobile-flutter-app/issues/97](https://github.com/linagora/linshare-mobile-flutter-app/issues/97)

Seems like new version of `receive_sharing_intent 1.4.3` is not stable yet. can not receive sharing files outside. So I config to use `1.4.1` only