### PR TITLE
Upgrade to Android target SDK 29, upgrade permission_handler lib

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -40,7 +40,7 @@ android {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId "com.linagora.android.linshare"
         minSdkVersion 16
-        targetSdkVersion 28
+        targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName
     }

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,6 +12,7 @@
         android:name="io.flutter.app.FlutterApplication"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:requestLegacyExternalStorage="true"
         android:roundIcon="@mipmap/ic_launcher_round">
         <activity
             android:name=".MainActivity"

--- a/doc/adr/0008-upgrade-android-target-sdk-29.md
+++ b/doc/adr/0008-upgrade-android-target-sdk-29.md
@@ -1,0 +1,40 @@
+# 8. upgrade-android-target-sdk-29
+
+Date: 2021-03-17
+
+## Status
+
+Accepted
+
+## Context
+
+- Download feature does not work when targeting into SDK 29 and above
+- From Android 10 and above, the [scoped storage](https://developer.android.com/training/data-storage#scoped-storage) has enabled that makes the access into external storage is limited. So, we need to adapt with this change.
+
+## Decision
+
+- Target to Android 10 (SDK 29) first, then adapt to Android 11 (SDK 30) later.
+- Temporarily [opt-out of scoped storage](https://developer.android.com/training/data-storage/use-cases#opt-out-scoped-storage) in Android 10:
+
+```xml
+<manifest ... >
+<!-- This attribute is "false" by default on apps targeting
+     Android 10 or higher. -->
+  <application android:requestLegacyExternalStorage="true" ... >
+    ...
+  </application>
+</manifest>
+```
+
+```groovy
+defaultConfig {
+    ...
+    targetSdkVersion 29
+    ...
+}
+```
+
+## Consequences
+
+- The download feature can work in Android 10 (SDK 29) and below
+- Android 11 (SDK 30) will be updated in the near future.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -104,7 +104,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.0
   pedantic: ^1.9.2
-  permission_handler: 5.0.1
+  permission_handler: 5.1.0+2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
- Upgrade to Android target SDK 29
- Upgrade permission_handler lib to `5.1.0+2` 

Signed-off-by: Huy Nguyen <qhuynguyen@linagora.com>