### PR TITLE
bug fixes Delete dialog overflows to the screen when the file name is too long

### DIFF
--- a/lib/presentation/view/modal_sheets/confirm_modal_sheet_builder.dart
+++ b/lib/presentation/view/modal_sheets/confirm_modal_sheet_builder.dart
@@ -38,6 +38,8 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:linshare_flutter_app/presentation/util/extensions/color_extension.dart';
 import 'package:linshare_flutter_app/presentation/util/router/app_navigation.dart';
+import 'package:linshare_flutter_app/presentation/widget/upload_file/upload_file_widget.dart';
+import 'package:domain/src/extension/string_extension.dart';
 
 typedef OnConfirmActionClick = void Function();
 
@@ -90,8 +92,20 @@ class ConfirmModalSheetBuilder {
             child: Column(
               children: <Widget>[
                 Padding(
-                  padding: EdgeInsets.only(left: 50, right: 50, top: 48, bottom: 19),
-                  child: Text(_title, style: TextStyle(fontSize: 16, color: AppColor.confirmDialogTitleTextColor), textAlign: TextAlign.center,)),
+                  padding: EdgeInsets.only(left: 70, right: 70, top: 48, bottom: 19),
+                  child: CustomPaint(
+                    size: Size(double.infinity, 36),
+                    painter: EllipsisTextPainter(
+                      text: TextSpan(text: _title, style: TextStyle(
+                          fontSize: 16,
+                          color: AppColor.confirmDialogTitleTextColor),
+                      ),
+                    ellipsis: _title.toMiddleEllipsis(),
+                    textAlign: TextAlign.center,
+                    maxLines: 3,
+                    ),
+                  ),
+                ),
                 Padding(
                   padding: EdgeInsets.only(top: 20),
                   child: Row(

--- a/lib/presentation/widget/upload_file/upload_file_widget.dart
+++ b/lib/presentation/widget/upload_file/upload_file_widget.dart
@@ -571,8 +571,9 @@ class EllipsisTextPainter extends CustomPainter {
   final TextSpan text;
   final int maxLines;
   final String ellipsis;
+  final TextAlign textAlign;
 
-  EllipsisTextPainter({this.text, this.ellipsis, this.maxLines}) : super();
+  EllipsisTextPainter({this.text, this.ellipsis, this.maxLines, this.textAlign}) : super();
 
   @override
   bool shouldRepaint(CustomPainter oldDelegate) => false;
@@ -582,6 +583,7 @@ class EllipsisTextPainter extends CustomPainter {
     var painter = TextPainter(
       text: text,
       maxLines: maxLines,
+      textAlign: textAlign,
       textDirection: TextDirection.ltr,
     )..ellipsis = ellipsis;
     painter.layout(maxWidth: size.width);


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/56970970/118365426-fbf19e00-b5c6-11eb-8983-017defde8541.png)
_title is one line long
![image](https://user-images.githubusercontent.com/56970970/118365571-80442100-b5c7-11eb-8571-52cd207f6f01.png)
_title is two lines long
![image](https://user-images.githubusercontent.com/56970970/118365636-cd27f780-b5c7-11eb-8d50-5c4aa06ed324.png)
_title is three lines long