### PR TITLE
LA-153 Fix Android notification status string

### DIFF
--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -36,4 +36,10 @@
 
 <resources>
     <string name="app_name">LinShare</string>
+    <string name="flutter_downloader_notification_started">Started</string>
+    <string name="flutter_downloader_notification_in_progress">In Progress</string>
+    <string name="flutter_downloader_notification_canceled">Canceled</string>
+    <string name="flutter_downloader_notification_failed">Failed</string>
+    <string name="flutter_downloader_notification_complete">Completed</string>
+    <string name="flutter_downloader_notification_paused">Paused</string>
 </resources>


### PR DESCRIPTION
Convert download status message to uppercase 

![Screenshot_1624608683](https://user-images.githubusercontent.com/29337364/123394353-42c0b380-d5c9-11eb-8c4e-05f25b7ca9e4.png)
