### PR TITLE
Add Intl Utils

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ messages_fr.dart
 messages_messages.dart
 messages_ru.dart
 messages_vi.dart
+l10n.dart

--- a/lib/presentation/localizations/app_localizations.dart
+++ b/lib/presentation/localizations/app_localizations.dart
@@ -31,7 +31,7 @@
 
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
-import 'package:linshare_flutter_app/l10n/messages_all.dart';
+import 'package:linshare_flutter_app/l10n/generated/intl/messages_all.dart';
 
 class AppLocalizations {
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -118,6 +118,7 @@ dependencies:
 
   # OIDC
   flutter_appauth: 1.0.0+1
+  intl_utils: ^2.4.0
 
   # datetime picker
   flutter_datetime_picker: 1.5.1
@@ -171,3 +172,23 @@ flutter:
   #
   # For details regarding fonts from package dependencies,
   # see https://flutter.dev/custom-fonts/#from-packages
+
+flutter_intl:
+  enabled: true # Required. Must be set to true to activate the package. Default: false
+  class_name: S # Optional. Sets the name for the generated localization class. Default: S
+  main_locale: en # Optional. Sets the main locale used for generating localization files. Provided value should consist of language code and optional script and country codes separated with underscore (e.g. 'en', 'en_GB', 'zh_Hans', 'zh_Hans_CN'). Default: en
+  arb_dir: lib/l10n # Optional. Sets the directory of your ARB resource files. Provided value should be a valid path on your system. Default: lib/l10n
+  output_dir: lib/l10n/generated # Optional. Sets the directory of generated localization files. Provided value should be a valid path on your system. Default: lib/generated
+  use_deferred_loading: false # Optional. Must be set to true to generate localization code that is loaded with deferred loading. Default: false
+  localizely: # Optional settings if you use Localizely platform. Read more: https://localizely.com/flutter-localization-workflow
+    project_id: # Get it from the https://app.localizely.com/projects page.
+    branch: # Get it from the “Branches” page on the Localizely platform, in case branching is enabled and you want to use a non-main branch.
+    upload_overwrite: # Set to true if you want to overwrite translations with upload. Default: false
+    upload_as_reviewed: # Set to true if you want to mark uploaded translations as reviewed. Default: false
+    upload_tag_added: # Optional list of tags to add to new translations with upload.
+    upload_tag_updated: # Optional list of tags to add to updated translations with upload.
+    upload_tag_removed: # Optional list of tags to add to removed translations with upload.
+    download_empty_as: # Set to empty|main|skip, to configure how empty translations should be exported from the Localizely platform. Default: empty
+    download_include_tags: # Optional list of tags to be downloaded. If not set, all string keys will be considered for download.
+    download_exclude_tags: # Optional list of tags to be excluded from download. If not set, all string keys will be considered for download.
+    ota_enabled: # Set to true if you want to use Localizely Over-the-air functionality. Default: false


### PR DESCRIPTION
Since `flutter pub run intl_translation:generate_from_arb` doesn't generate files with null safety, I suggest to add a recent package that support null safety : https://pub.dev/packages/intl_utils 

command : `flutter pub run intl_utils:generate`

We can discuss about output file tho