### PR TITLE
LA-592 Bug fixes Failed to share file from other app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -31,7 +31,7 @@
         android:roundIcon="@mipmap/ic_launcher_round">
         <activity
             android:name=".MainActivity"
-            android:launchMode="singleTop"
+            android:launchMode="singleTask"
             android:theme="@style/LaunchTheme"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"

--- a/doc/adr/0002-receive-shared-file-from-other-app.md
+++ b/doc/adr/0002-receive-shared-file-from-other-app.md
@@ -27,6 +27,23 @@ The following config is for receiving single file shared Android (AndroidManifes
          <data android:mimeType="*/*" />
      </intent-filter>
 ```
+
+- Update on 14/09/2021:
+    
+    - By the issue from [here](https://github.com/KasemJaffer/receive_sharing_intent/issues/81), need to update setting on Android `AndroidManifest.xml`:
+      Change from:
+      ```xml
+          android:launchMode="singleTop"
+      ```
+      to:
+      ```xml
+          android:launchMode="singleTask"
+      ```
+  
+    - Adapt to version change [`1.4.5`](https://pub.dev/packages/receive_sharing_intent/changelog#145):
+      - Support null-safety
+      - New CFBundleURLSchemes 
+  
 ## Decision
 
 We decided that LinShare app support receiving single file shared at the moment.

--- a/doc/adr/0010-migrate-to-null-safety-support.md
+++ b/doc/adr/0010-migrate-to-null-safety-support.md
@@ -87,11 +87,3 @@ Follow official guideline: [https://dart.dev/null-safety/migration-guide](https:
             Check the issue [#162](https://github.com/fluttercommunity/flutter_uploader/issues/162)
         
             &rarr; Solution: Use `flutter_uploader: 1.2.1`
-        
-        - **receive_sharing_intent: 1.4.5**
-            Check the issue [#116](https://github.com/KasemJaffer/receive_sharing_intent/issues/116)
-            
-            &rarr; Solution: Use `receive_sharing_intent: 1.4.1`
-
-...
-(TBD)

--- a/ios/LinshareShareExtension/ShareViewController.swift
+++ b/ios/LinshareShareExtension/ShareViewController.swift
@@ -201,7 +201,7 @@ class ShareViewController: SLComposeServiceViewController {
     }
 
     private func redirectToHostApp(type: RedirectType) {
-        let url = URL(string: "com.linagora.linshare://dataUrl=\(sharedKey)#\(type)")
+        let url = URL(string: "ShareMedia-\(hostAppBundleIdentifier)://dataUrl=\(sharedKey)#\(type)")
         var responder = self as UIResponder?
         let selectorOpenURL = sel_registerName("openURL:")
 

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -32,7 +32,7 @@
 			<string>Editor</string>
 			<key>CFBundleURLSchemes</key>
 			<array>
-				<string>com.linagora.linshare</string>
+				<string>ShareMedia-$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 				<string>linsharemobile.com</string>
 			</array>
 		</dict>

--- a/lib/presentation/widget/upload_file/upload_file_manager.dart
+++ b/lib/presentation/widget/upload_file/upload_file_manager.dart
@@ -52,8 +52,7 @@ class UploadFileManager {
     if(_pendingListFileInfo.isClosed) {
       _pendingListFileInfo = BehaviorSubject.seeded([]);
     } else {
-      closeUploadFileManagerStream();
-      _pendingListFileInfo = BehaviorSubject.seeded([]);
+      _pendingListFileInfo.add([]);
     }
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -70,7 +70,7 @@ dependencies:
   redux_logging: 0.5.0
 
   # receive_sharing_intent
-  receive_sharing_intent: 1.4.1
+  receive_sharing_intent: 1.4.5
 
   # intl
   intl_generator: 0.2.0+0


### PR DESCRIPTION
- Ticket: #592 
- Problem resolved:
    - Fix: Failed to share file from other app
    - Fix: Upgrade to null-safety version; the backlog problem (migrating null-safety) here: https://github.com/linagora/linshare-mobile-flutter-app/commit/24356e0382b3c4c40469d702a232d6315d5ffbfd
    - Fix: Share intent cause instance for Android
- Demo:

https://user-images.githubusercontent.com/29337364/133189410-470b0c14-ab46-4165-a414-d57d55b71538.mp4


