### PR TITLE
LA-653 Fix bug offline file lost in refreshing

### DIFF
--- a/domain/lib/src/model/sharedspacedocument/work_group_document.dart
+++ b/domain/lib/src/model/sharedspacedocument/work_group_document.dart
@@ -75,6 +75,47 @@ class WorkGroupDocument extends WorkGroupNode {
       lastAuthor,
       listTreeNode);
 
+  WorkGroupDocument copyWith(
+      {WorkGroupNodeId? workGroupNodeId,
+      WorkGroupNodeId? parentWorkGroupNodeId,
+      WorkGroupNodeType? type,
+      SharedSpaceId? sharedSpaceId,
+      DateTime? creationDate,
+      DateTime? modificationDate,
+      String? description,
+      String? name,
+      Account? lastAuthor,
+      List<TreeNode>? listTreeNode,
+      int? size,
+      MediaType? mediaType,
+      bool? hasThumbnail,
+      DateTime? uploadDate,
+      bool? hasRevision,
+      String? sha256sum,
+      String? localPath,
+      SyncOfflineState? syncOfflineState}) {
+    return WorkGroupDocument(
+      workGroupNodeId ?? this.workGroupNodeId,
+      parentWorkGroupNodeId,
+      type,
+      sharedSpaceId ?? this.sharedSpaceId,
+      creationDate ?? this.creationDate,
+      modificationDate ?? this.modificationDate,
+      description,
+      name ?? this.name,
+      lastAuthor ?? this.lastAuthor,
+      listTreeNode ?? treePath,
+      size ?? this.size,
+      mediaType ?? this.mediaType,
+      hasThumbnail ?? this.hasThumbnail,
+      uploadDate ?? this.uploadDate,
+      hasRevision ?? this.hasRevision,
+      sha256sum ?? this.sha256sum,
+      localPath: localPath,
+      syncOfflineState: syncOfflineState ?? this.syncOfflineState
+    );
+  }
+
   bool isOfflineMode() => localPath != null && localPath!.isNotEmpty;
 
   @override

--- a/lib/presentation/widget/shared_space_document/shared_space_document_viewmodel.dart
+++ b/lib/presentation/widget/shared_space_document/shared_space_document_viewmodel.dart
@@ -1130,7 +1130,14 @@ class SharedSpaceDocumentNodeViewModel extends BaseViewModel {
         .where((element) => element.isOfflineMode())
         .toList();
     if (listWorkGroupDocumentAvailableOffline.isNotEmpty) {
-      _autoSyncOfflineManager.syncOfflineSharedSpaceDocument(listWorkGroupDocumentAvailableOffline);
+      if(isRootFolder()) {
+        final nodeListToSaveOffline = listWorkGroupDocumentAvailableOffline.map((WorkGroupDocument node) {
+          return node.copyWith(parentWorkGroupNodeId: null);
+        }).toList();
+        _autoSyncOfflineManager.syncOfflineSharedSpaceDocument(nodeListToSaveOffline);
+      } else {
+        _autoSyncOfflineManager.syncOfflineSharedSpaceDocument(listWorkGroupDocumentAvailableOffline);
+      }
     }
   }
 


### PR DESCRIPTION
- Ticket: #653 
- Note:
    - The root cause is that:
        - After refreshing the list (online), the `parentWorkGroupNodeId` will be updated from server, so this makes it `NOT NULL`
        - In the offline env, this function [`getListWorkGroupCacheInSharedSpace`](https://github.com/linagora/linshare-mobile-flutter-app/blob/1867058e16229403ce9e19777571b11dbf567251/data/lib/src/local/shared_space_document_database_manager.dart#L139) is checking `parentNodeId` nullable. So, the file is not fit the condition -> it will not appear on the list.
    - Solution:
        - When refreshing the list, we will not update the `parentWorkGroupNodeId` value from server into local database. Instead of that, we keep the current `parentWorkGroupNodeId` value. This only happens to database, not affect current app data (in memory)
- Demo: 

https://user-images.githubusercontent.com/29337364/135592523-da2020d5-9ba6-4c8e-9dba-fea95027c494.mp4


