### PR TITLE
[Drive] Support Drive function

### DIFF
--- a/lib/presentation/widget/shared_space/shared_space_viewmodel.dart
+++ b/lib/presentation/widget/shared_space/shared_space_viewmodel.dart
@@ -221,11 +221,42 @@ class SharedSpaceViewModel extends BaseViewModel {
     return store.state.uiState.isInSearchState();
   }
 
-  void openContextMenu(BuildContext context, SharedSpaceNodeNested sharedSpace, List<Widget> actionTiles, {Widget? footerAction}) {
-    store.dispatch(_handleContextMenuAction(context, sharedSpace, actionTiles, footerAction: footerAction));
+  void openDriveContextMenu(BuildContext context, SharedSpaceNodeNested nodeNested, List<Widget> actionTiles, {Widget? footerAction}) {
+    store.dispatch(
+      _handleDriveContextMenuAction(
+        context,
+        nodeNested,
+        actionTiles,
+        footerAction: footerAction));
   }
 
-  ThunkAction<AppState> _handleContextMenuAction(
+  void openContextMenu(BuildContext context, SharedSpaceNodeNested nodeNested, List<Widget> actionTiles, {Widget? footerAction}) {
+    store.dispatch(
+      _handleWorkGroupContextMenuAction(
+        context,
+        nodeNested,
+        actionTiles,
+        footerAction: footerAction));
+  }
+
+  ThunkAction<AppState> _handleDriveContextMenuAction(
+    BuildContext context,
+    SharedSpaceNodeNested nodeNested,
+    List<Widget> actionTiles,
+    {Widget? footerAction}
+  ) {
+    return (Store<AppState> store) async {
+      ContextMenuBuilder(context)
+        .addHeader(ContextMenuHeaderBuilder(
+            Key('drive_context_menu_header'),
+            SharedSpaceNodeNestedPresentationFile.fromSharedSpaceNodeNested(nodeNested))
+          .build())
+        .addTiles(actionTiles)
+        .build();
+    };
+  }
+
+  ThunkAction<AppState> _handleWorkGroupContextMenuAction(
       BuildContext context,
       SharedSpaceNodeNested sharedSpace,
       List<Widget> actionTiles,

--- a/lib/presentation/widget/shared_space/shared_space_widget.dart
+++ b/lib/presentation/widget/shared_space/shared_space_widget.dart
@@ -352,11 +352,24 @@ class _SharedSpaceWidgetState extends State<SharedSpaceWidget> {
                         height: 24,
                         fit: BoxFit.fill,
                       ),
-                      onPressed: () => sharedSpaceViewModel.openContextMenu(context,
-                          sharedSpace.element, _contextMenuActionTiles(context, sharedSpace),
-                          footerAction: _contextMenuFooterAction(sharedSpace.element)));
+                      onPressed: () => _onPressContextMenu(context, sharedSpace)
+                    );
             }),
         onLongPress: () => sharedSpaceViewModel.selectItem(sharedSpace));
+  }
+
+  void _onPressContextMenu(BuildContext context, SelectableElement<SharedSpaceNodeNested> sharedSpace) {
+    switch (sharedSpace.element.nodeType) {
+      case LinShareNodeType.DRIVE:
+        sharedSpaceViewModel.openDriveContextMenu(context, sharedSpace.element, []);
+        break;
+      default:
+        sharedSpaceViewModel.openContextMenu(
+          context,
+          sharedSpace.element,
+          _contextMenuActionTiles(context, sharedSpace),
+          footerAction: _contextMenuFooterAction(sharedSpace.element));
+    }
   }
 
   List<Widget> _contextMenuActionTiles(BuildContext context, SelectableElement<SharedSpaceNodeNested> sharedSpace) {


### PR DESCRIPTION
### separate context menu for Drive
- [x] Done

### open drive 
- [ ] all child workgroup of drive will be showed by API
```
@GET /webservice/rest/user/v4/shared_spaces?parent={id}&withRole=true
```

- [ ] support drive in destination picker
- [ ] temporary disable create workgroup inside drive