### PR TITLE
🐛 Fix:  Fixed wrong create workspace button text translation key (#1217)

### DIFF
--- a/lib/presentation/util/extensions/linshare_node_type_extension.dart
+++ b/lib/presentation/util/extensions/linshare_node_type_extension.dart
@@ -144,9 +144,9 @@ extension LinShareNodeTypeExtension on LinShareNodeType {
       case LinShareNodeType.DRIVE:
         return AppLocalizations.of(context).create_drive;
       case LinShareNodeType.WORK_GROUP:
-        return AppLocalizations.of(context).create_workgroup;
+        return AppLocalizations.of(context).create_new_workgroup;
       case LinShareNodeType.WORK_SPACE:
-        return AppLocalizations.of(context).create_workspace;
+        return AppLocalizations.of(context).create_new_workspace;
     }
   }
 


### PR DESCRIPTION
### Description
[GitLab issue](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1217)

updated the `create workspace` button translation key, from `create_workspace` to `create_new_workspace`

### before

![image](https://github.com/linagora/linshare-mobile-flutter-app/assets/160496984/e81d9e69-d9d1-4ffd-a188-1e16c5992080)


### after
![after](https://github.com/linagora/linshare-mobile-flutter-app/assets/160496984/7b06cc39-60c3-4f34-ba01-f68fed014d7d)

