### PR TITLE
Bug fix/cannot login when token is deleted

### DIFF
--- a/data/lib/src/datasource_impl/authentication_datasource_impl.dart
+++ b/data/lib/src/datasource_impl/authentication_datasource_impl.dart
@@ -35,6 +35,7 @@ import 'package:data/data.dart';
 import 'package:data/src/network/model/response/user_response.dart';
 import 'package:dio/dio.dart';
 import 'package:domain/domain.dart';
+import 'package:flutter/foundation.dart';
 
 class AuthenticationDataSourceImpl implements AuthenticationDataSource {
 
@@ -103,7 +104,9 @@ class AuthenticationDataSourceImpl implements AuthenticationDataSource {
       return userRes.toUser();
     }).catchError((error) {
       _remoteExceptionThrower.throwRemoteException(error, handler: (DioError error) {
-          if(error.response!.statusCode==401){
+        final errorCode = error.response?.headers.value(Constant.linShareAuthErrorCode) ?? '1';
+        final authErrorCode = LinShareErrorCode(int.tryParse(errorCode) ?? 1);
+          if(authErrorCode.value==1000){
             throw NotAuthorizedUser();
           }
         throw UnknownError(error.response?.statusMessage!);

--- a/data/lib/src/datasource_impl/authentication_datasource_impl.dart
+++ b/data/lib/src/datasource_impl/authentication_datasource_impl.dart
@@ -103,6 +103,9 @@ class AuthenticationDataSourceImpl implements AuthenticationDataSource {
       return userRes.toUser();
     }).catchError((error) {
       _remoteExceptionThrower.throwRemoteException(error, handler: (DioError error) {
+          if(error.response!.statusCode==401){
+            throw NotAuthorizedUser();
+          }
         throw UnknownError(error.response?.statusMessage!);
       });
     });

--- a/data/lib/src/datasource_impl/authentication_datasource_impl.dart
+++ b/data/lib/src/datasource_impl/authentication_datasource_impl.dart
@@ -35,7 +35,6 @@ import 'package:data/data.dart';
 import 'package:data/src/network/model/response/user_response.dart';
 import 'package:dio/dio.dart';
 import 'package:domain/domain.dart';
-import 'package:flutter/foundation.dart';
 
 class AuthenticationDataSourceImpl implements AuthenticationDataSource {
 
@@ -106,7 +105,7 @@ class AuthenticationDataSourceImpl implements AuthenticationDataSource {
       _remoteExceptionThrower.throwRemoteException(error, handler: (DioError error) {
         final errorCode = error.response?.headers.value(Constant.linShareAuthErrorCode) ?? '1';
         final authErrorCode = LinShareErrorCode(int.tryParse(errorCode) ?? 1);
-          if(authErrorCode.value==1000){
+          if(authErrorCode.canNotGetJwt()){
             throw NotAuthorizedUser();
           }
         throw UnknownError(error.response?.statusMessage!);

--- a/data/lib/src/network/config/retry_authentication_interceptors.dart
+++ b/data/lib/src/network/config/retry_authentication_interceptors.dart
@@ -64,6 +64,9 @@ class RetryAuthenticationInterceptors extends InterceptorsWrapper {
       super.onError(dioError, handler);
     }
   }catch(exception){
+    if(retries>=_max_retry_count){
+      _permanentToken=null;
+    }
       super.onError(dioError, handler);
   }
   }

--- a/data/lib/src/network/config/retry_authentication_interceptors.dart
+++ b/data/lib/src/network/config/retry_authentication_interceptors.dart
@@ -29,8 +29,10 @@
 //  3 and <http://www.linshare.org/licenses/LinShare-License_AfferoGPL-v3.pdf> for
 //  the Additional Terms applicable to LinShare software.
 
+import 'package:data/src/util/constant.dart';
 import 'package:dio/dio.dart';
 import 'package:domain/domain.dart';
+import 'package:flutter/foundation.dart';
 
 class RetryAuthenticationInterceptors extends InterceptorsWrapper {
   static const int _max_retry_count = 3;
@@ -50,10 +52,11 @@ class RetryAuthenticationInterceptors extends InterceptorsWrapper {
     final requestOptions = dioError.requestOptions;
     final extraInRequest = requestOptions.extra;
     var retries = extraInRequest[RETRY_KEY] ?? 0;
+    var errorCode = dioError.response?.headers.value(Constant.linShareAuthErrorCode) ?? '1';
+    debugPrint("$errorCode----------------------------------------------------");
     try{
-    if (_isAuthenticationError(dioError, retries)) {
+    if (_isAuthenticationError(dioError, retries) && errorCode !='1005')  {
       retries++;
-
       requestOptions.headers.addAll({AUTHORIZATION_KEY: _getTokenAsBearerHeader(_permanentToken?.token)});
       requestOptions.extra = {RETRY_KEY: retries};
 
@@ -64,9 +67,6 @@ class RetryAuthenticationInterceptors extends InterceptorsWrapper {
       super.onError(dioError, handler);
     }
   }catch(exception){
-    if(retries>=_max_retry_count){
-      _permanentToken=null;
-    }
       super.onError(dioError, handler);
   }
   }

--- a/data/lib/src/network/config/retry_authentication_interceptors.dart
+++ b/data/lib/src/network/config/retry_authentication_interceptors.dart
@@ -52,8 +52,9 @@ class RetryAuthenticationInterceptors extends InterceptorsWrapper {
     final extraInRequest = requestOptions.extra;
     var retries = extraInRequest[RETRY_KEY] ?? 0;
     var errorCode = dioError.response?.headers.value(Constant.linShareAuthErrorCode) ?? '1';
+    final authErrorCode = LinShareErrorCode(int.tryParse(errorCode) ?? 1);
     try{
-    if (_isAuthenticationError(dioError, retries) && errorCode !='1005')  {
+    if (_isAuthenticationError(dioError, retries) && !authErrorCode.isTokenDeleted())  {
       retries++;
       requestOptions.headers.addAll({AUTHORIZATION_KEY: _getTokenAsBearerHeader(_permanentToken?.token)});
       requestOptions.extra = {RETRY_KEY: retries};

--- a/data/lib/src/network/config/retry_authentication_interceptors.dart
+++ b/data/lib/src/network/config/retry_authentication_interceptors.dart
@@ -32,7 +32,6 @@
 import 'package:data/src/util/constant.dart';
 import 'package:dio/dio.dart';
 import 'package:domain/domain.dart';
-import 'package:flutter/foundation.dart';
 
 class RetryAuthenticationInterceptors extends InterceptorsWrapper {
   static const int _max_retry_count = 3;
@@ -53,7 +52,6 @@ class RetryAuthenticationInterceptors extends InterceptorsWrapper {
     final extraInRequest = requestOptions.extra;
     var retries = extraInRequest[RETRY_KEY] ?? 0;
     var errorCode = dioError.response?.headers.value(Constant.linShareAuthErrorCode) ?? '1';
-    debugPrint("$errorCode----------------------------------------------------");
     try{
     if (_isAuthenticationError(dioError, retries) && errorCode !='1005')  {
       retries++;
@@ -64,7 +62,7 @@ class RetryAuthenticationInterceptors extends InterceptorsWrapper {
       return handler.resolve(response);
 
     } else {
-      super.onError(dioError, handler);
+      return handler.reject(dioError);
     }
   }catch(exception){
       super.onError(dioError, handler);

--- a/data/lib/src/network/config/retry_authentication_interceptors.dart
+++ b/data/lib/src/network/config/retry_authentication_interceptors.dart
@@ -65,7 +65,7 @@ class RetryAuthenticationInterceptors extends InterceptorsWrapper {
     } else {
       return handler.reject(dioError);
     }
-  }catch(exception){
+  } catch(exception) {
       super.onError(dioError, handler);
   }
   }

--- a/data/lib/src/network/config/retry_authentication_interceptors.dart
+++ b/data/lib/src/network/config/retry_authentication_interceptors.dart
@@ -50,6 +50,7 @@ class RetryAuthenticationInterceptors extends InterceptorsWrapper {
     final requestOptions = dioError.requestOptions;
     final extraInRequest = requestOptions.extra;
     var retries = extraInRequest[RETRY_KEY] ?? 0;
+    try{
     if (_isAuthenticationError(dioError, retries)) {
       retries++;
 
@@ -62,6 +63,9 @@ class RetryAuthenticationInterceptors extends InterceptorsWrapper {
     } else {
       super.onError(dioError, handler);
     }
+  }catch(exception){
+      super.onError(dioError, handler);
+  }
   }
 
   bool _isAuthenticationError(DioError dioError, int retryCount) {

--- a/domain/lib/domain.dart
+++ b/domain/lib/domain.dart
@@ -293,6 +293,7 @@ export 'src/usecases/authentication/create_permanent_token_interactor.dart';
 export 'src/usecases/authentication/create_permanent_token_oidc_interactor.dart';
 export 'src/usecases/authentication/credential_view_state.dart';
 export 'src/usecases/authentication/delete_permanent_token_interactor.dart';
+export 'src/usecases/authentication/remove_permanent_token_interactor.dart';
 export 'src/usecases/authentication/delete_token_oidc_interactor.dart';
 export 'src/usecases/authentication/get_authorized_user_interactor.dart';
 export 'src/usecases/authentication/get_credential_interactor.dart';

--- a/domain/lib/src/errorcode/business_error_code.dart
+++ b/domain/lib/src/errorcode/business_error_code.dart
@@ -39,4 +39,6 @@ class BusinessErrorCode {
   static final workspaceLimit = LinShareErrorCode(50016);
   static final nestedWorkgroupLimit = LinShareErrorCode(55508);
   static final uploadRequestLimitReach = LinShareErrorCode(31416);
+  static final noValidTokenFound = LinShareErrorCode(1005);
+
 }

--- a/domain/lib/src/errorcode/business_error_code.dart
+++ b/domain/lib/src/errorcode/business_error_code.dart
@@ -39,6 +39,6 @@ class BusinessErrorCode {
   static final workspaceLimit = LinShareErrorCode(50016);
   static final nestedWorkgroupLimit = LinShareErrorCode(55508);
   static final uploadRequestLimitReach = LinShareErrorCode(31416);
-  static final noValidTokenFound = LinShareErrorCode(1005);
+  static final noValidTokenFound = [LinShareErrorCode(1005)];
 
 }

--- a/domain/lib/src/errorcode/business_error_code.dart
+++ b/domain/lib/src/errorcode/business_error_code.dart
@@ -39,6 +39,7 @@ class BusinessErrorCode {
   static final workspaceLimit = LinShareErrorCode(50016);
   static final nestedWorkgroupLimit = LinShareErrorCode(55508);
   static final uploadRequestLimitReach = LinShareErrorCode(31416);
-  static final noValidTokenFound = [LinShareErrorCode(1005)];
+  static final noValidPermanentTokenFound = [LinShareErrorCode(1005)];
+  static final noValidJwt = [LinShareErrorCode(1000)];
 
 }

--- a/domain/lib/src/model/linshare_error_code.dart
+++ b/domain/lib/src/model/linshare_error_code.dart
@@ -43,6 +43,11 @@ extension LinShareErrorCodeExtension on LinShareErrorCode {
 
   bool isAuthenticateErrorUserLocked() =>
       BusinessErrorCode.authenErrorUserLocked.contains(this);
+
   bool isTokenDeleted()=>
-      BusinessErrorCode.noValidTokenFound.contains(this);
+      BusinessErrorCode.noValidPermanentTokenFound.contains(this);
+
+  bool canNotGetJwt()=>
+      BusinessErrorCode.noValidJwt.contains(this);
 }
+

--- a/domain/lib/src/model/linshare_error_code.dart
+++ b/domain/lib/src/model/linshare_error_code.dart
@@ -43,4 +43,6 @@ extension LinShareErrorCodeExtension on LinShareErrorCode {
 
   bool isAuthenticateErrorUserLocked() =>
       BusinessErrorCode.authenErrorUserLocked.contains(this);
+  bool isTokenDeleted()=>
+      BusinessErrorCode.noValidTokenFound.contains(this);
 }

--- a/domain/lib/src/usecases/authentication/get_authorized_user_interactor.dart
+++ b/domain/lib/src/usecases/authentication/get_authorized_user_interactor.dart
@@ -42,7 +42,14 @@ class GetAuthorizedInteractor {
   Future<Either<Failure, Success>> execute() async {
     try {
       final user = await authenticationRepository.getAuthorizedUser()
-          .onError((error, stackTrace) => authenticationRepository.getAuthorizedUserOffline());
+          .onError((error, stackTrace) {
+            if(error is NotAuthorizedUser){
+                throw error;
+            }
+            else{
+               return authenticationRepository.getAuthorizedUserOffline();
+            }
+          });
       final baseUrl = (await credentialRepository.getBaseUrl()).toString();
       if (_needSetup2FA(user)) {
         return Left(NeedSetup2FA());

--- a/domain/lib/src/usecases/authentication/get_authorized_user_interactor.dart
+++ b/domain/lib/src/usecases/authentication/get_authorized_user_interactor.dart
@@ -45,7 +45,7 @@ class GetAuthorizedInteractor {
           .onError((error, stackTrace) {
             if(error is NotAuthorizedUser){
                 throw error;
-            }else{
+            } else {
                return authenticationRepository.getAuthorizedUserOffline();
             }
           });

--- a/domain/lib/src/usecases/authentication/get_authorized_user_interactor.dart
+++ b/domain/lib/src/usecases/authentication/get_authorized_user_interactor.dart
@@ -45,8 +45,7 @@ class GetAuthorizedInteractor {
           .onError((error, stackTrace) {
             if(error is NotAuthorizedUser){
                 throw error;
-            }
-            else{
+            }else{
                return authenticationRepository.getAuthorizedUserOffline();
             }
           });

--- a/domain/lib/src/usecases/authentication/remove_permanent_token_interactor.dart
+++ b/domain/lib/src/usecases/authentication/remove_permanent_token_interactor.dart
@@ -1,0 +1,60 @@
+// LinShare is an open source filesharing software, part of the LinPKI software
+// suite, developed by Linagora.
+//
+// Copyright (C) 2020 LINAGORA
+//
+// This program is free software: you can redistribute it and/or modify it under the
+// terms of the GNU Affero General Public License as published by the Free Software
+// Foundation, either version 3 of the License, or (at your option) any later version,
+// provided you comply with the Additional Terms applicable for LinShare software by
+// Linagora pursuant to Section 7 of the GNU Affero General Public License,
+// subsections (b), (c), and (e), pursuant to which you must notably (i) retain the
+// display in the interface of the “LinShare™” trademark/logo, the "Libre & Free" mention,
+// the words “You are using the Free and Open Source version of LinShare™, powered by
+// Linagora © 2009–2020. Contribute to Linshare R&D by subscribing to an Enterprise
+// offer!”. You must also retain the latter notice in all asynchronous messages such as
+// e-mails sent with the Program, (ii) retain all hypertext links between LinShare and
+// http://www.linshare.org, between linagora.com and Linagora, and (iii) refrain from
+// infringing Linagora intellectual property rights over its trademarks and commercial
+// brands. Other Additional Terms apply, see
+// <http://www.linshare.org/licenses/LinShare-License_AfferoGPL-v3.pdf>
+// for more details.
+// This program is distributed in the hope that it will be useful, but WITHOUT ANY
+// WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+// FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for
+// more details.
+// You should have received a copy of the GNU Affero General Public License and its
+// applicable Additional Terms for LinShare along with this program. If not, see
+// <http://www.gnu.org/licenses/> for the GNU Affero General Public License version
+//  3 and <http://www.linshare.org/licenses/LinShare-License_AfferoGPL-v3.pdf> for
+//  the Additional Terms applicable to LinShare software.
+
+import 'dart:developer' as developer;
+
+import 'package:dartz/dartz.dart';
+import 'package:domain/domain.dart';
+
+import 'logout_view_state.dart';
+
+class RemovePermanentTokenInteractor {
+  final TokenRepository tokenRepository;
+  final CredentialRepository credentialRepository;
+
+  RemovePermanentTokenInteractor(
+      this.tokenRepository,
+      this.credentialRepository
+      );
+
+  Future<Either<Failure, Success>> execute() async {
+    try {
+        Future.sync(() async {
+          await tokenRepository.removeToken();
+          developer.log('execute(): deleteToken', name: 'DeletePermanentTokenInteractor');
+          await credentialRepository.removeBaseUrl();
+      });
+      return Right(LogoutViewState());
+    } catch (exception) {
+      return Left(LogoutFailure(exception));
+    }
+  }
+}

--- a/lib/presentation/di/module/app_module.dart
+++ b/lib/presentation/di/module/app_module.dart
@@ -332,6 +332,9 @@ class AppModule {
       getIt<AuthenticationRepository>(),
       getIt<TokenRepository>(),
       getIt<CredentialRepository>()));
+    getIt.registerFactory(() => RemovePermanentTokenInteractor(
+        getIt<TokenRepository>(),
+        getIt<CredentialRepository>()));
     getIt.registerFactory(() => LogoutOidcInteractor(
       getIt<AuthenticationOIDCRepository>(),
       getIt<CredentialRepository>()

--- a/lib/presentation/di/module/widget_module.dart
+++ b/lib/presentation/di/module/widget_module.dart
@@ -493,6 +493,7 @@ class WidgetModule {
         getIt<DeletePermanentTokenInteractor>(),
         getIt<AppNavigation>(),
         getIt<SaveAuthorizedUserInteractor>(),
+        getIt<RemovePermanentTokenInteractor>()
     ));
   }
 

--- a/lib/presentation/widget/authentication/authentication_viewmodel.dart
+++ b/lib/presentation/widget/authentication/authentication_viewmodel.dart
@@ -91,7 +91,13 @@ class AuthenticationViewModel extends BaseViewModel {
       _appNavigation.popAndPush(
         RoutePaths.second_factor_authentication,
         arguments: SecondFactorAuthenticationArguments(_authenticationArguments!.baseUrl));
-    } else {
+    }else if (failure is GetAuthorizedUserFailure &&
+        failure.exception is NotAuthorizedUser) {
+      store.dispatch(logoutAction());
+      _appNavigation.pushAndRemoveAll(RoutePaths.loginRoute,
+          );
+    } 
+    else {
       store.dispatch(initializeHomeView(_appNavigation, _authenticationArguments!.baseUrl));
     }
   }

--- a/lib/presentation/widget/authentication/authentication_viewmodel.dart
+++ b/lib/presentation/widget/authentication/authentication_viewmodel.dart
@@ -45,6 +45,7 @@ import 'authentication_arguments.dart';
 class AuthenticationViewModel extends BaseViewModel {
   final GetAuthorizedInteractor _getAuthorizedInteractor;
   final DeletePermanentTokenInteractor deletePermanentTokenInteractor;
+  final RemovePermanentTokenInteractor _removePermanentTokenInteractor;
   final SaveAuthorizedUserInteractor _saveAuthorizedUserInteractor;
   final AppNavigation _appNavigation;
   AuthenticationArguments? _authenticationArguments;
@@ -55,6 +56,7 @@ class AuthenticationViewModel extends BaseViewModel {
     this.deletePermanentTokenInteractor,
     this._appNavigation,
     this._saveAuthorizedUserInteractor,
+      this._removePermanentTokenInteractor
   ) : super(store) {
     _getAuthorizedUser();
   }
@@ -93,7 +95,7 @@ class AuthenticationViewModel extends BaseViewModel {
         arguments: SecondFactorAuthenticationArguments(_authenticationArguments!.baseUrl));
     }else if (failure is GetAuthorizedUserFailure &&
         failure.exception is NotAuthorizedUser) {
-      store.dispatch(logoutAction());
+       store.dispatch(removeTokenAction());
       _appNavigation.pushAndRemoveAll(RoutePaths.loginRoute,
           );
     } 
@@ -107,7 +109,11 @@ class AuthenticationViewModel extends BaseViewModel {
       await deletePermanentTokenInteractor.execute();
     };
   }
-
+  ThunkAction<AppState> removeTokenAction() {
+    return (Store<AppState> store) async {
+      await _removePermanentTokenInteractor.execute();
+    };
+  }
   ThunkAction<AppState> _saveAuthorizedUserAction(User user) {
     return (Store<AppState> store) async {
       await _saveAuthorizedUserInteractor.execute(user);


### PR DESCRIPTION
## Description 
[gitlab ticket](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1238)
   
 When the permanent token is deleted from the web, the app gets stuck loading

### Root cause
  when the permanent token is deleted the `RetryAuthenticationInterceptors` fails to get a new token and throws an unhandled exception causing the app to get stuck loading

### Solution
- wrapping the code in the interceptor in try catch block 
- logout the user locally to prevent the account from getting locked