### PR TITLE
Fixed donwloads in sharedSpace

### DIFF
--- a/data/lib/src/datasource_impl/shared_space_document_datasource_impl.dart
+++ b/data/lib/src/datasource_impl/shared_space_document_datasource_impl.dart
@@ -165,6 +165,7 @@ class SharedSpaceDocumentDataSourceImpl implements SharedSpaceDocumentDataSource
             savedDir: externalStorageDirPath,
             headers: {Constant.authorization: 'Bearer ${token.token}'},
             showNotification: true,
+            saveInPublicStorage: true,
             openFileFromNotification: true)));
 
       return taskIds


### PR DESCRIPTION
### Description
[GitLab issue](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1201)
#### Root cause 
  Flutter_downloader requires `saveInPublicStorage` flag to be set to true for devices with android version greater than android Q(10) to be able to save in downloads folder
#### Solution
 Set the `saveInPublicStorage` flag to `true` in  the  Flutter_Downloader call in `Download_document method`