### PR TITLE
Fixed can create file with empty or special chars name

### DIFF
--- a/lib/presentation/widget/shared_space_document/shared_space_document_viewmodel.dart
+++ b/lib/presentation/widget/shared_space_document/shared_space_document_viewmodel.dart
@@ -795,12 +795,13 @@ class SharedSpaceDocumentNodeViewModel extends BaseViewModel {
   }
 
   String? _getErrorString(BuildContext context, WorkGroupNode? workGroupNode, String value) {
-    if(workGroupNode == null) {
-      return '';
+    var listName = <String>[];
+
+    if (workGroupNode != null) {
+      listName = workGroupNode is WorkGroupDocument
+          ? _workGroupNodesList.whereType<WorkGroupDocument>().map((node) => node.name).toList()
+          : _workGroupNodesList.whereType<WorkGroupFolder>().map((node) => node.name).toList();
     }
-    final listName = workGroupNode is WorkGroupDocument
-        ? _workGroupNodesList.whereType<WorkGroupDocument>().map((node) => node.name).toList()
-        : _workGroupNodesList.whereType<WorkGroupFolder>().map((node) => node.name).toList();
 
     return _verifyNameInteractor.execute(value, [
       EmptyNameValidator(),


### PR DESCRIPTION
## Description
 [gitlab issue](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1272)

## Root cause
  when `workgroupNode` is null the code return an empty string without performing the other tests
 #### demo of the issue




https://github.com/linagora/linshare-mobile-flutter-app/assets/160496984/c0859c85-4dbd-428a-8df3-f1f277448a37

## Solution
  changed the condition to allow other test to be performed

#### demo


https://github.com/linagora/linshare-mobile-flutter-app/assets/160496984/9c78b1e6-08e3-485d-bbeb-18bb6ccb88e5

