### PR TITLE
LA-1296 changed key value for oidc-Jwt

### DIFF
--- a/data/lib/src/util/oidc_parser.dart
+++ b/data/lib/src/util/oidc_parser.dart
@@ -25,7 +25,7 @@ class OIDCParser {
       final responseTypeMatch = regExpResponseType.allMatches(matchString).first.group(3) ?? '';
 
       String oidcTokenType = DomainConstant.opaqueOidc;
-      if (oidcTypeMatch == 'Oidc-Jwt') {
+      if (oidcTypeMatch == DomainConstant.jwtOidc) {
         oidcTokenType = DomainConstant.jwtOidc;
       }
 

--- a/data/lib/src/util/oidc_parser.dart
+++ b/data/lib/src/util/oidc_parser.dart
@@ -25,7 +25,7 @@ class OIDCParser {
       final responseTypeMatch = regExpResponseType.allMatches(matchString).first.group(3) ?? '';
 
       String oidcTokenType = DomainConstant.opaqueOidc;
-      if (oidcTypeMatch == 'JWT') {
+      if (oidcTypeMatch == 'Oidc-Jwt') {
         oidcTokenType = DomainConstant.jwtOidc;
       }
 


### PR DESCRIPTION
## Description 
[gitlab issue](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1296)
  
when trying to login using sso with oidc-jwt the authentication fails

## Root cause
 The `oidc_parser` is comparing to a wrong value for oidc token type `JWT` instead of  `Oidc-Jwt` so it's always defaulting to using `Oidc-opaque`

## Solution 
Changed to the right value 
