### PR TITLE
LA-1295 Fixed missing password protected checkbox

### DIFF
--- a/lib/presentation/widget/upload_request_creation/upload_request_creation_widget.dart
+++ b/lib/presentation/widget/upload_request_creation/upload_request_creation_widget.dart
@@ -169,7 +169,7 @@ class _UploadRequestCreationWidgetState extends State<UploadRequestCreationWidge
                         ..addOnSizeTypeNotifier(_model.totalFileSizeTypeNotifier))
                       .build()
                     : null)
-                ..addPasswordProtectedInput(creationState.uploadRequestCreation?.passwordProtected != null
+                ..addPasswordProtectedInput(creationState.uploadRequestCreation?.protectPasswordSetting != null
                     ? (CheckboxInputFieldBuilder()
                         ..setKey(Key('password_protected_input'))
                         ..setTitle(AppLocalizations.of(context).password_protected)


### PR DESCRIPTION
## Description 
[gitlab issue](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1295)

### Root cause
  Wrong attribute is used to determine if the checkbox should be displayed or not

### Solution
Changed the attribute to `protectPasswordSetting` instead of  `passwordProtected`
