### PR TITLE
LA-1294 Fixed error in logs in workgoup activities

### DIFF
--- a/data/lib/src/network/linshare_http_client.dart
+++ b/data/lib/src/network/linshare_http_client.dart
@@ -200,7 +200,7 @@ class LinShareHttpClient {
   }
 
   AuditLogEntryUserDto? _convertToAuditLogEntryNodeChild(Map<String, dynamic> nodeChildJson) {
-    if (nodeChildJson['type'] == AuditLogEntryType.WORKGROUP.value) {
+    if (nodeChildJson['type'] == AuditLogEntryType.WORK_GROUP.value) {
       return SharedSpaceNodeAuditLogEntryDto.fromJson(nodeChildJson);
     } else if (nodeChildJson['type'] == AuditLogEntryType.WORKGROUP_MEMBER.value) {
       return SharedSpaceMemberAuditLogEntryDto.fromJson(nodeChildJson);

--- a/domain/lib/src/extension/audit_log_entry_type.dart
+++ b/domain/lib/src/extension/audit_log_entry_type.dart
@@ -35,8 +35,8 @@ extension AuditLogEntryTypeExtension on AuditLogEntryType {
 
   String get value {
     switch(this) {
-      case AuditLogEntryType.WORKGROUP:
-        return 'WORKGROUP';
+      case AuditLogEntryType.WORK_GROUP:
+        return 'WORK_GROUP';
       case AuditLogEntryType.WORKGROUP_MEMBER:
         return 'WORKGROUP_MEMBER';
       case AuditLogEntryType.WORKGROUP_FOLDER:
@@ -58,7 +58,7 @@ extension AuditLogEntryTypeExtension on AuditLogEntryType {
 
   ClientLogAction generateClientLogAction(AuditLogEntry auditLogEntry) {
     switch(this) {
-      case AuditLogEntryType.WORKGROUP:
+      case AuditLogEntryType.WORK_GROUP:
         if (auditLogEntry.action == LogAction.CREATE) {
           return ClientLogAction.CREATE;
         } else if (auditLogEntry.action == LogAction.DELETE) {

--- a/domain/lib/src/model/audit/audit_log_entry_type.dart
+++ b/domain/lib/src/model/audit/audit_log_entry_type.dart
@@ -29,8 +29,9 @@
 //  3 and <http://www.linshare.org/licenses/LinShare-License_AfferoGPL-v3.pdf> for
 //  the Additional Terms applicable to LinShare software.
 
+
 enum AuditLogEntryType {
-  WORKGROUP,
+  WORK_GROUP,
   WORKGROUP_MEMBER,
   WORKGROUP_FOLDER,
   WORKGROUP_DOCUMENT,

--- a/lib/presentation/util/extensions/audit_log_entry_type_extension.dart
+++ b/lib/presentation/util/extensions/audit_log_entry_type_extension.dart
@@ -40,7 +40,7 @@ extension AuditLogEntryTypeExtension on AuditLogEntryType {
       Map<AuditLogActionMessageParam, dynamic> actionMessages,
       bool isCurrentUserAuthor) {
     switch (this) {
-      case AuditLogEntryType.WORKGROUP:
+      case AuditLogEntryType.WORK_GROUP:
         switch (clientLogAction) {
           case ClientLogAction.CREATE:
             return {

--- a/lib/presentation/util/extensions/audit_log_entry_user_extension.dart
+++ b/lib/presentation/util/extensions/audit_log_entry_user_extension.dart
@@ -42,7 +42,7 @@ extension AuditLogEntryUserExtension on AuditLogEntryUser {
 
   String getAuditLogIconPath(AppImagePaths imagePath) {
     switch (type) {
-      case AuditLogEntryType.WORKGROUP:
+      case AuditLogEntryType.WORK_GROUP:
         return imagePath.icSharedSpace;
       case AuditLogEntryType.WORKGROUP_MEMBER:
         return imagePath.icAddMember;


### PR DESCRIPTION
## Desciption
[gitlab issue](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1294)

### Root cause 


  The activity logs causing the error have the type `WORK_GROUP`  instead of  `WORKGROUP`  which leads to a problem while parsing
![image](https://github.com/linagora/linshare-mobile-flutter-app/assets/160496984/18dfba1d-9c77-47e6-ad30-9eb6680c16ee)
### Solution  
 Changed  `WORK

GROUP` to `WORK_GROUP`
![Screenshot_1](https://github.com/linagora/linshare-mobile-flutter-app/assets/160496984/95e773f0-03de-4421-afd9-9eed7a7f8845)