### PR TITLE
LA-1351 fixed wrong expiration date in recieved shares

### DIFF
--- a/lib/presentation/widget/received_share_details/received_share_details_widget.dart
+++ b/lib/presentation/widget/received_share_details/received_share_details_widget.dart
@@ -129,7 +129,7 @@ class _ReceivedShareDetailsWidgetState extends State<ReceivedShareDetailsWidget>
               _receivedShareInformationTile(AppLocalizations.of(context).created,
                   state.receivedShare!.creationDate.getMMMddyyyyFormatString()),
               _receivedShareInformationTile(AppLocalizations.of(context).expiration,
-                  state.receivedShare!.creationDate.getMMMddyyyyFormatString()),
+                state.receivedShare!.expirationDate.getMMMddyyyyFormatString()),
             ],
           ),
           Divider(),


### PR DESCRIPTION
## Issue
[GitLab issue](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1351)

## Root Cause
the field `creationDate` is used instead of `expirationDate` 