### PR TITLE
LA-1357 fixed downloads failing for recieved shares

### DIFF
--- a/data/lib/src/datasource_impl/received_share_datasource_impl.dart
+++ b/data/lib/src/datasource_impl/received_share_datasource_impl.dart
@@ -93,7 +93,8 @@ class ReceivedShareDataSourceImpl extends ReceivedShareDataSource {
             savedDir: externalStorageDirPath,
             headers: {Constant.authorization: 'Bearer ${token.token}'},
             showNotification: true,
-            openFileFromNotification: true)));
+            openFileFromNotification: true,
+            saveInPublicStorage: true)));
 
     return taskIds
         .where((taskId) => taskId != null)


### PR DESCRIPTION
## Issue
 [gitlab ticket](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1357)

## Description
  when trying to download files from recieved shares the download fails

## Solution
 the parameter `saveInPublicStorage` needs to be set to true to save files in donwloads folder

## Demo
[Received_share_download.webm](https://github.com/user-attachments/assets/14ac9d46-8556-4ecf-8f55-7a931d927045)


