### PR TITLE
LA-1358: Add validation for names ending with dot in workspace, workgroup, and folder for creation/editing

### DIFF
--- a/lib/presentation/util/extensions/linshare_node_type_extension.dart
+++ b/lib/presentation/util/extensions/linshare_node_type_extension.dart
@@ -57,6 +57,10 @@ extension LinShareNodeTypeExtension on LinShareNodeType {
           return AppLocalizations.of(context).node_name_already_exists(AppLocalizations.of(context).workgroup);
         } else if (exception is SpecialCharacterException) {
           return AppLocalizations.of(context).node_name_contain_special_character(AppLocalizations.of(context).workgroup);
+        } else if (exception is LastDotException) {
+          return AppLocalizations.of(context).node_name_contain_last_dot(
+              AppLocalizations.of(context).workgroup);
+                 
         } else {
           return null;
         }
@@ -67,6 +71,9 @@ extension LinShareNodeTypeExtension on LinShareNodeType {
           return AppLocalizations.of(context).node_name_already_exists(AppLocalizations.of(context).workspace);
         } else if (exception is SpecialCharacterException) {
           return AppLocalizations.of(context).node_name_contain_special_character(AppLocalizations.of(context).workspace);
+        } else if (exception is LastDotException) {
+          return AppLocalizations.of(context).node_name_contain_last_dot(
+              AppLocalizations.of(context).workspace);
         } else {
           return null;
         }
@@ -86,12 +93,14 @@ extension LinShareNodeTypeExtension on LinShareNodeType {
         return [
           EmptyNameValidator(),
           DuplicateNameValidator(sharedSpaceNodes.map((node) => node.name).toList()),
-          SpecialCharacterValidator()
+          SpecialCharacterValidator(),
+          LastDotValidator()
         ];
       case LinShareNodeType.WORK_SPACE:
         return [
           EmptyNameValidator(),
-          SpecialCharacterValidator()
+          SpecialCharacterValidator(),
+          LastDotValidator()
         ];
     }
   }

--- a/lib/presentation/widget/shared_space_document/shared_space_document_viewmodel.dart
+++ b/lib/presentation/widget/shared_space_document/shared_space_document_viewmodel.dart
@@ -807,7 +807,7 @@ class SharedSpaceDocumentNodeViewModel extends BaseViewModel {
       EmptyNameValidator(),
       DuplicateNameValidator(listName),
       SpecialCharacterValidator(),
-      if (workGroupNode is WorkGroupDocument) LastDotValidator()
+      LastDotValidator()
     ]).fold((failure) {
       if (failure is VerifyNameFailure) {
         final nodeName = workGroupNode is WorkGroupDocument


### PR DESCRIPTION
## [Gitlab issue](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1358) 
### Current behaviour
 Currently Workgroups workspaces and folders can be named and renamed with a dot at the end
###  Expected behaviour
 There should be an error message: Folder name cannot finishes by character "."
### Solution 
 added validation for this case
 ### demo
[dot.webm](https://github.com/user-attachments/assets/8916bcb0-884f-463e-b1ef-fabae7cfabed)
