### PR TITLE
LA 1352 new files appear in offline mode

### DIFF
--- a/data/lib/src/datasource/received_share_datasource.dart
+++ b/data/lib/src/datasource/received_share_datasource.dart
@@ -67,4 +67,8 @@ abstract class ReceivedShareDataSource {
   Future<List<ReceivedShare>> getAllReceivedShareOffline();
 
   Future<bool> disableOffline(ShareId shareId, String localPath);
+
+  Future<List<ReceivedShare>> getAllReceivedSharesForRecipient(
+      String recipient);
+
 }

--- a/data/lib/src/datasource_impl/local_received_share_datasource.dart
+++ b/data/lib/src/datasource_impl/local_received_share_datasource.dart
@@ -116,4 +116,16 @@ class LocalReceivedShareDataSource extends ReceivedShareDataSource {
       throw LocalUnknownError(error);
     });
   }
+  
+  @override
+  Future<List<ReceivedShare>> getAllReceivedSharesForRecipient(
+      String recipient) {
+    return Future.sync(() async {
+      return await _receivedShareDatabaseManager
+          .getListDataForRecipient(recipient);
+    }).catchError((error) {
+      throw LocalUnknownError(error);
+    });
+  }
+  
 }

--- a/data/lib/src/datasource_impl/received_share_datasource_impl.dart
+++ b/data/lib/src/datasource_impl/received_share_datasource_impl.dart
@@ -217,4 +217,10 @@ class ReceivedShareDataSourceImpl extends ReceivedShareDataSource {
   Future<bool> disableOffline(ShareId shareId, String localPath) {
     throw UnimplementedError();
   }
+  
+  @override
+  Future<List<ReceivedShare>> getAllReceivedSharesForRecipient(String recipient) {
+    // TODO: implement getAllReceivedSharesForRecipient
+    throw UnimplementedError();
+  }
 }

--- a/data/lib/src/extensions/user_extension.dart
+++ b/data/lib/src/extensions/user_extension.dart
@@ -50,4 +50,10 @@ extension UserExtension on User {
       secondFARequired
     );
   }
+  
+  GenericUser toGenericUser() {
+    return GenericUser(
+      mail,
+    );
+  }
 }

--- a/data/lib/src/local/received_share_database_manager.dart
+++ b/data/lib/src/local/received_share_database_manager.dart
@@ -100,10 +100,14 @@ class ReceivedShareDatabaseManager
   }
 
   Future<List<ReceivedShare>> getListDataForRecipient(String mail) async {
-    String todayDate = DateTime.now().toIso8601String();
+    final now = DateTime.now();
+    final todayDate =
+        DateTime(now.year, now.month, now.day, now.hour, now.minute).toIso8601String();
+    final queryCondition =
+        '${ReceivedShareTable.MAIL_RECIPIENT} !="" AND ${ReceivedShareTable.MAIL_RECIPIENT} = ? AND ${ReceivedShareTable.EXPIRATION_DATE} >= ?';
     final res = await _databaseClient.getListDataWithCondition(
         ReceivedShareTable.TABLE_NAME,
-        '${ReceivedShareTable.MAIL_RECIPIENT} !="" AND ${ReceivedShareTable.MAIL_RECIPIENT} = ? AND ${ReceivedShareTable.EXPIRATION_DATE} >= ?',
+        queryCondition,
         [mail, todayDate]);
     return res.isNotEmpty
         ? res

--- a/data/lib/src/local/received_share_database_manager.dart
+++ b/data/lib/src/local/received_share_database_manager.dart
@@ -38,7 +38,8 @@ import 'package:domain/domain.dart';
 
 import 'model/received_share_cache.dart';
 
-class ReceivedShareDatabaseManager extends LinShareDatabaseManager<ReceivedShare> {
+class ReceivedShareDatabaseManager
+    extends LinShareDatabaseManager<ReceivedShare> {
   final DatabaseClient _databaseClient;
 
   ReceivedShareDatabaseManager(this._databaseClient);
@@ -98,4 +99,17 @@ class ReceivedShareDatabaseManager extends LinShareDatabaseManager<ReceivedShare
     return res > 0 ? true : false;
   }
 
+  Future<List<ReceivedShare>> getListDataForRecipient(String mail) async {
+    String todayDate = DateTime.now().toIso8601String();
+    final res = await _databaseClient.getListDataWithCondition(
+        ReceivedShareTable.TABLE_NAME,
+        '${ReceivedShareTable.MAIL_RECIPIENT} !="" AND ${ReceivedShareTable.MAIL_RECIPIENT} = ? AND ${ReceivedShareTable.EXPIRATION_DATE} >= ?',
+        [mail, todayDate]);
+    return res.isNotEmpty
+        ? res
+            .map((mapObject) =>
+                ReceivedShareCache.fromJson(mapObject).toReceivedShare())
+            .toList()
+        : [];
+  }
 }

--- a/data/lib/src/repository/received/received_share_repository_impl.dart
+++ b/data/lib/src/repository/received/received_share_repository_impl.dart
@@ -104,4 +104,9 @@ class ReceivedShareRepositoryImpl extends ReceivedShareRepository {
   Future<bool> disableOffline(ShareId shareId, String localPath) {
     return _receivedShareDataSources[DataSourceType.local]!.disableOffline(shareId, localPath);
   }
+  
+  @override
+  Future<List<ReceivedShare>> getAllReceivedShareOfflineByRecipient(String recipient) {
+    return _receivedShareDataSources[DataSourceType.local]!.getAllReceivedSharesForRecipient(recipient);
+  }
 }

--- a/data/test/local/received_share_database_manager_test.dart
+++ b/data/test/local/received_share_database_manager_test.dart
@@ -1,0 +1,66 @@
+import 'package:data/data.dart';
+import 'package:data/src/local/config/received_share_table.dart';
+import 'package:data/src/local/model/received_share_cache.dart';
+import 'package:domain/domain.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mockito/mockito.dart';
+import 'package:mockito/annotations.dart';
+import 'package:testshared/fixture/received_share_fixture.dart';
+import 'document_database_manager_test.mocks.dart';
+
+@GenerateMocks([DatabaseClient])
+void main() {
+  late MockDatabaseClient mockDatabaseClient;
+  late ReceivedShareDatabaseManager receivedShareDatabaseManager;
+  late DateTime now;
+  late String todayDate;
+  setUp(() {
+    mockDatabaseClient = MockDatabaseClient();
+    receivedShareDatabaseManager =
+        ReceivedShareDatabaseManager(mockDatabaseClient);
+    now = DateTime.now();
+    todayDate = DateTime(now.year, now.month, now.day, now.hour, now.minute)
+        .toIso8601String();
+  });
+
+  group('getListDataForRecipient', () {
+    test(
+        'getListDataForRecipient returns filtered and mapped data for a specific recipient',
+        () async {
+      when(mockDatabaseClient.getListDataWithCondition(
+        ReceivedShareTable.TABLE_NAME,
+        '${ReceivedShareTable.MAIL_RECIPIENT} !="" AND ${ReceivedShareTable.MAIL_RECIPIENT} = ? AND ${ReceivedShareTable.EXPIRATION_DATE} >= ?',
+        [RECIPIENT_1.mail, todayDate],
+      )).thenAnswer((_) async => [
+            receivedShare1.toReceivedShareCache().toJson(),
+          ]);
+
+      final result = await receivedShareDatabaseManager
+          .getListDataForRecipient(RECIPIENT_1.mail);
+
+      expect(result, isA<List<ReceivedShare>>());
+      expect(result.length, 1);
+      expect(result.first.shareId, receivedShare1.shareId);
+    });
+    test(
+      'getListDataForRecipient returns an empty list when no data matches the recipient',
+      () async {
+        when(mockDatabaseClient.getListDataWithCondition(
+          ReceivedShareTable.TABLE_NAME,
+          '${ReceivedShareTable.MAIL_RECIPIENT} !="" AND ${ReceivedShareTable.MAIL_RECIPIENT} = ? AND ${ReceivedShareTable.EXPIRATION_DATE} >= ?',
+          [RECIPIENT_1.mail, todayDate],
+        )).thenAnswer((_) async => []);
+
+        final result = await receivedShareDatabaseManager
+            .getListDataForRecipient(RECIPIENT_1.mail);
+        expect(result, isA<List<ReceivedShare>>());
+        expect(result.isEmpty, true);
+        verify(mockDatabaseClient.getListDataWithCondition(
+          ReceivedShareTable.TABLE_NAME,
+          '${ReceivedShareTable.MAIL_RECIPIENT} !="" AND ${ReceivedShareTable.MAIL_RECIPIENT} = ? AND ${ReceivedShareTable.EXPIRATION_DATE} >= ?',
+          [RECIPIENT_1.mail, todayDate],
+        )).called(1);
+      },
+    );
+  });
+}

--- a/domain/lib/domain.dart
+++ b/domain/lib/domain.dart
@@ -512,3 +512,4 @@ export 'src/usecases/workgroup/get_all_workgroups_interactor.dart';
 export 'src/usecases/workgroup/get_all_workgroups_offline_interactor.dart';
 export 'src/usecases/workgroup/workgroup_exception.dart';
 export 'src/usecases/workgroup/workgroup_view_state.dart';
+export 'src/usecases/received/remove_deleted_received_share_from_local_database.dart';

--- a/domain/lib/src/extension/received_share_extensions.dart
+++ b/domain/lib/src/extension/received_share_extensions.dart
@@ -55,4 +55,22 @@ extension ReceivedShareExtensions on ReceivedShare {
       localPath: localPath,
       syncOfflineState: SyncOfflineState.completed);
   }
+  
+  ReceivedShare withRecipient(GenericUser recipient) {
+    return ReceivedShare(
+        shareId,
+        name,
+        creationDate,
+        modificationDate,
+        expirationDate,
+        description,
+        recipient,
+        mediaType,
+        sender,
+        downloaded,
+        size,
+        hasThumbnail,
+        localPath: localPath,
+        syncOfflineState: syncOfflineState);
+  }
 }

--- a/domain/lib/src/repository/received/received_share_repository.dart
+++ b/domain/lib/src/repository/received/received_share_repository.dart
@@ -68,5 +68,8 @@ abstract class ReceivedShareRepository {
 
   Future<List<ReceivedShare>> getAllReceivedShareOffline();
 
+  Future<List<ReceivedShare>> getAllReceivedShareOfflineByRecipient(
+      String recipient);
+
   Future<bool> disableOffline(ShareId shareId, String localPath);
 }

--- a/domain/lib/src/usecases/received/get_all_received_shares_interactor.dart
+++ b/domain/lib/src/usecases/received/get_all_received_shares_interactor.dart
@@ -38,11 +38,16 @@ import 'package:domain/src/repository/received/received_share_repository.dart';
 import 'package:domain/src/state/failure.dart';
 import 'package:domain/src/state/success.dart';
 import 'package:domain/src/usecases/received/received_share_view_state.dart';
+import 'package:collection/collection.dart';
+import 'package:domain/src/usecases/received/remove_deleted_received_share_from_local_database.dart';
 
 class GetAllReceivedSharesInteractor {
   final ReceivedShareRepository _receivedShareRepository;
+  final RemoveDeletedReceivedShareFromLocalDatabaseInteractor
+      _removeDeletedReceivedShareFromLocalDatabase;
 
-  GetAllReceivedSharesInteractor(this._receivedShareRepository);
+  GetAllReceivedSharesInteractor(this._receivedShareRepository,
+      this._removeDeletedReceivedShareFromLocalDatabase);
 
   Future<Either<Failure, Success>> execute(String recipient) async {
     try {
@@ -50,6 +55,9 @@ class GetAllReceivedSharesInteractor {
           .onError((error, stackTrace) => _receivedShareRepository
               .getAllReceivedShareOfflineByRecipient(recipient));
       final combinedReceivedShares = List<ReceivedShare>.empty(growable: true);
+
+      _removeDeletedReceivedShareFromLocalDatabase.execute(
+          receivedShares, recipient);
 
       if (receivedShares.isNotEmpty) {
         for (final received in receivedShares) {

--- a/domain/lib/src/usecases/received/get_all_received_shares_interactor.dart
+++ b/domain/lib/src/usecases/received/get_all_received_shares_interactor.dart
@@ -44,10 +44,11 @@ class GetAllReceivedSharesInteractor {
 
   GetAllReceivedSharesInteractor(this._receivedShareRepository);
 
-  Future<Either<Failure, Success>> execute() async {
+  Future<Either<Failure, Success>> execute(String recipient) async {
     try {
       final receivedShares = await _receivedShareRepository.getAllReceivedShares()
-        .onError((error, stackTrace) => _receivedShareRepository.getAllReceivedShareOffline());
+          .onError((error, stackTrace) => _receivedShareRepository
+              .getAllReceivedShareOfflineByRecipient(recipient));
       final combinedReceivedShares = List<ReceivedShare>.empty(growable: true);
 
       if (receivedShares.isNotEmpty) {

--- a/domain/lib/src/usecases/received/make_received_share_offline_interactor.dart
+++ b/domain/lib/src/usecases/received/make_received_share_offline_interactor.dart
@@ -48,7 +48,8 @@ class MakeReceivedShareOfflineInteractor {
     this._credentialRepository
   );
 
-  Future<Either<Failure, Success>> execute(ReceivedShare receivedShare) async {
+  Future<Either<Failure, Success>> execute(
+      ReceivedShare receivedShare, GenericUser recipient) async {
     try {
       final downloadPreviewType = receivedShare.mediaType.isImageFile()
           ? DownloadPreviewType.image
@@ -69,7 +70,10 @@ class MakeReceivedShareOfflineInteractor {
         });
 
       if (filePath.isNotEmpty) {
-        final result = await _receivedShareRepository.makeAvailableOffline(receivedShare, filePath);
+        ReceivedShare receivedShareWithRecipient =
+            receivedShare.withRecipient(recipient);
+        final result = await _receivedShareRepository.makeAvailableOffline(
+            receivedShareWithRecipient, filePath);
         if (result) {
           return Right<Failure, Success>(MakeAvailableOfflineReceivedShareViewState(OfflineModeActionResult.successful, filePath));
         } else {

--- a/domain/lib/src/usecases/received/remove_deleted_received_share_from_local_database.dart
+++ b/domain/lib/src/usecases/received/remove_deleted_received_share_from_local_database.dart
@@ -1,0 +1,21 @@
+import 'package:domain/domain.dart';
+import 'package:collection/collection.dart';
+
+class RemoveDeletedReceivedShareFromLocalDatabaseInteractor {
+  final ReceivedShareRepository _receivedShareRepository;
+
+  RemoveDeletedReceivedShareFromLocalDatabaseInteractor(
+      this._receivedShareRepository);
+
+  Future<void> execute(
+      List<ReceivedShare> receivedShares, String recipient) async {
+    var localReceivedShares = await _receivedShareRepository
+        .getAllReceivedShareOfflineByRecipient(recipient);
+    final receivedShareIds = receivedShares.map((received) => received.shareId).toSet();
+    for (final local in localReceivedShares) {
+      if (!receivedShareIds.contains(local.shareId)) {
+        await _receivedShareRepository.disableOffline(local.shareId, local.localPath ?? '');
+      }
+    }
+  }
+}

--- a/domain/lib/src/usecases/received/remove_deleted_received_share_from_local_database.dart
+++ b/domain/lib/src/usecases/received/remove_deleted_received_share_from_local_database.dart
@@ -1,5 +1,5 @@
+import 'dart:developer';
 import 'package:domain/domain.dart';
-import 'package:collection/collection.dart';
 
 class RemoveDeletedReceivedShareFromLocalDatabaseInteractor {
   final ReceivedShareRepository _receivedShareRepository;
@@ -9,13 +9,19 @@ class RemoveDeletedReceivedShareFromLocalDatabaseInteractor {
 
   Future<void> execute(
       List<ReceivedShare> receivedShares, String recipient) async {
-    var localReceivedShares = await _receivedShareRepository
-        .getAllReceivedShareOfflineByRecipient(recipient);
-    final receivedShareIds = receivedShares.map((received) => received.shareId).toSet();
-    for (final local in localReceivedShares) {
-      if (!receivedShareIds.contains(local.shareId)) {
-        await _receivedShareRepository.disableOffline(local.shareId, local.localPath ?? '');
+    try {
+      var localReceivedShares = await _receivedShareRepository
+          .getAllReceivedShareOfflineByRecipient(recipient);
+      final receivedShareIds =
+          receivedShares.map((received) => received.shareId).toSet();
+      for (final local in localReceivedShares) {
+        if (!receivedShareIds.contains(local.shareId)) {
+          await _receivedShareRepository.disableOffline(
+              local.shareId, local.localPath ?? '');
+        }
       }
+    } catch (exception) {
+      log('RemoveDeletedReceivedShareFromLocalDatabaseInteractor: $exception');
     }
   }
 }

--- a/lib/presentation/di/module/app_module.dart
+++ b/lib/presentation/di/module/app_module.dart
@@ -356,7 +356,12 @@ class AppModule {
     getIt.registerFactory(() => GetSharedSpacesRootNodeInfoInteractor(getIt<SharedSpaceDocumentRepository>()));
     getIt.registerFactory(() => DownloadMultipleFileIOSInteractor(getIt<DownloadFileIOSInteractor>()));
     getIt.registerFactory(() => GetAuthorizedInteractor(getIt<AuthenticationRepository>(), getIt<CredentialRepository>()));
-    getIt.registerFactory(() => GetAllReceivedSharesInteractor(getIt<ReceivedShareRepository>()));
+    getIt.registerFactory(() =>
+        RemoveDeletedReceivedShareFromLocalDatabaseInteractor(
+            getIt<ReceivedShareRepository>()));
+    getIt.registerFactory(() => GetAllReceivedSharesInteractor(
+        getIt<ReceivedShareRepository>(),
+        getIt<RemoveDeletedReceivedShareFromLocalDatabaseInteractor>()));
     getIt.registerFactory(() => CopyToMySpaceInteractor(getIt<DocumentRepository>()));
     getIt.registerFactory(() => CopyMultipleFilesToMySpaceInteractor(getIt<CopyToMySpaceInteractor>()));
     getIt.registerFactory(() => SearchDocumentInteractor());

--- a/lib/presentation/widget/received/received_share_viewmodel.dart
+++ b/lib/presentation/widget/received/received_share_viewmodel.dart
@@ -619,8 +619,7 @@ class ReceivedShareViewModel extends BaseViewModel {
   OnlineThunkAction _makeAvailableOfflineAction(ReceivedShare receivedShare, int position) {
     return OnlineThunkAction((Store<AppState> store) async {
       final recipient = GenericUser(store.state.account.user?.mail ?? '');
-      await _makeReceivedShareOfflineInteractor
-          .execute(receivedShare, recipient)
+      await _makeReceivedShareOfflineInteractor.execute(receivedShare, recipient)
         .then((result) => result.fold(
           (failure) {
             _receivedSharesList[position] = receivedShare.toSyncOffline(syncOfflineState: SyncOfflineState.none);

--- a/lib/presentation/widget/received/received_share_viewmodel.dart
+++ b/lib/presentation/widget/received/received_share_viewmodel.dart
@@ -169,7 +169,10 @@ class ReceivedShareViewModel extends BaseViewModel {
   ThunkAction<AppState> _getAllReceivedShareAction() {
     return (Store<AppState> store) async {
       store.dispatch(StartReceivedShareLoadingAction());
-      await _getAllReceivedInteractor.execute().then((result) => result.fold(
+      final currentUser = store.state.account.user;
+      await _getAllReceivedInteractor
+          .execute(currentUser?.mail ?? '')
+          .then((result) => result.fold(
         (failure) {
           store.dispatch(ReceivedShareGetAllReceivedSharesAction(Left(failure)));
           _receivedSharesList = [];
@@ -369,9 +372,10 @@ class ReceivedShareViewModel extends BaseViewModel {
     return (Store<AppState> store) async {
       store.dispatch(StartReceivedShareLoadingAction());
 
+      final currentUser = store.state.account.user;
       await Future.wait([
         _getSorterInteractor.execute(OrderScreen.receivedShares),
-        _getAllReceivedInteractor.execute()
+        _getAllReceivedInteractor.execute(currentUser?.mail ?? '')
       ]).then((response) async {
         response[0].fold((failure) {
           store.dispatch(ReceivedShareGetSorterAction(Sorter.fromOrderScreen(OrderScreen.receivedShares)));
@@ -614,7 +618,9 @@ class ReceivedShareViewModel extends BaseViewModel {
 
   OnlineThunkAction _makeAvailableOfflineAction(ReceivedShare receivedShare, int position) {
     return OnlineThunkAction((Store<AppState> store) async {
-      await _makeReceivedShareOfflineInteractor.execute(receivedShare)
+      final recipient = GenericUser(store.state.account.user?.mail ?? '');
+      await _makeReceivedShareOfflineInteractor
+          .execute(receivedShare, recipient)
         .then((result) => result.fold(
           (failure) {
             _receivedSharesList[position] = receivedShare.toSyncOffline(syncOfflineState: SyncOfflineState.none);


### PR DESCRIPTION
### [Gitlab Ticket](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1352)

### Root cause

- When saving received shares in the local database, the recipient's information is not tracked. As a result, when retrieving all received shares, documents that were saved by other users on the same device are mistakenly included in the  received shares list.
- When a received share is deleted or expires, it still remains present in the local database, leading to the display of unavailable documents in the received shares list in offline mode

## Solution 
 - Added recipient information when saving received shares to the local database when data is retrieved.
 - Added test for expiration date while retrieving
 - Implemented an interactor to remove received shares from the local database when they are no longer available (deleted or expired)
 ## Demo

[1352.webm](https://github.com/user-attachments/assets/c05badb4-3350-4d12-a5e7-01e5e774d168)


 