### PR TITLE
LA-1354 removed deleting last version of a file

### DIFF
--- a/lib/presentation/localizations/app_localizations.dart
+++ b/lib/presentation/localizations/app_localizations.dart
@@ -3023,6 +3023,14 @@ class AppLocalizations {
         name: 'reach_upload_request_limit_message_own_server'
     );
   }
+  
+  String get you_cant_delete_the_last_version {
+    return Intl.message(
+      "You can't delete the last version, try to delete the whole document",
+      name: 'you_cant_delete_the_last_version',
+    );
+  }
+
 }
 
 class AppLocalizationsDelegate extends LocalizationsDelegate<AppLocalizations> {

--- a/lib/presentation/util/toast_message_handler.dart
+++ b/lib/presentation/util/toast_message_handler.dart
@@ -429,6 +429,10 @@ class ToastMessageHandler {
         } else if (failure is CopyToSharedSpaceFailure) {
           appToast.showErrorToast(AppLocalizations.of(context).cannot_copy_file_to_shared_space);
           _cleanSharedSpaceNodeVersionsViewState();
+      } else if (failure is RemoveFinalSharedSpaceNodeVersionFailure) {
+        appToast.showErrorToast(
+            AppLocalizations.of(context).you_cant_delete_the_last_version);
+        _cleanSharedSpaceNodeVersionsViewState();
         }
       },
       (success) {

--- a/lib/presentation/widget/shared_space_document/shared_space_node_versions/shared_space_node_versions_viewmodel.dart
+++ b/lib/presentation/widget/shared_space_document/shared_space_node_versions/shared_space_node_versions_viewmodel.dart
@@ -228,7 +228,7 @@ class SharedSpaceNodeVersionsViewModel extends BaseViewModel {
       .onConfirmAction(AppLocalizations.of(context).delete, (_) {
             _appNavigation.popBack();
             if (finalVersion) {
-              store.dispatch(_removeFinalNodeVersionAction(nodeVersionArguments.workGroupNode));
+             store.dispatch(SharedSpaceNodeVersionsAction(Left(RemoveFinalSharedSpaceNodeVersionFailure())));
             } else {
               store.dispatch(_removeNodeVersionAction(document));
             }


### PR DESCRIPTION
# [Gitlab Ticket](https://ci.linagora.com/linagora/lgs/linshare/products/linshare-ui-user/-/issues/1354)

## Current behaviour 
When i delete the last version of a file its deleted
## Expectation
 When I delete the final version of a file, there will be a message: You can't delete the last version, try to delete the whole document
## Demo 

https://github.com/user-attachments/assets/64f4ac65-4b46-4b64-8dfa-3bd2a78c2b45

